### PR TITLE
Sort events

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ layout: base
     <div class="container">
         <div class="row">
             <h2 class="text-center white-text">Our events</h2>
-            {% assign sorted = site.data.events | sort: 'date','last' %}
+            {% assign sorted = site.data.events | sort: 'date','last' | reverse %}
             {% for event in sorted %}               
                 <div class="col-sm-6 col-md-4 ">
                     <a {% unless event.url == null %} href="{{event.url}}" {% endunless %} target="_blank" class="event-url">


### PR DESCRIPTION
## Description
Sort the events from more recent to oldest. Right now the events list show the oldest first and you have to scroll down to the bottom to see most recent events.

## Related Issues
*None*

## Some questions
- [x] I read the contributing guidelines
- [ ] I'm adding a new event/footer link
- [ ] I'm editing an existing event/footer link
- [x] I'm adding a new feature/fixing a bug

## Additional Notes
PR made bu a 🐱with ❤️